### PR TITLE
Fix deployment

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,7 +1,5 @@
-FROM tomcat:8
+FROM tomcat:8.5.51-jdk8-openjdk
 
 ADD conf/ /usr/local/tomcat/conf/
 
 RUN ["rm", "-r", "/usr/local/tomcat/webapps"]
-
-RUN apt-get update && apt-get install --assume-yes openjdk-8-jdk

--- a/docker/backend/conf/Catalina/localhost/ROOT.xml
+++ b/docker/backend/conf/Catalina/localhost/ROOT.xml
@@ -1,6 +1,6 @@
 <Context>
     <!-- All environment variables in this context are optional -->
-    <Environment name="java_home" value="/usr/lib/jvm/java-8-openjdk-amd64" type="java.lang.String"
+    <Environment name="java_home" value="/usr/local/openjdk-8" type="java.lang.String"
                  override="false"/>
     <Environment name="app_output_dir" value="/logs/" type="java.lang.String" override="false"/>
     <Environment name="timeout" type="java.lang.String" value="5000" override="false"/>


### PR DESCRIPTION
* Update `JAVA_HOME` path in the Catalina `ROOT.xml` for the default one in the `openjdk-8`.

* Update backend service Dockerfile to use an updated Tomcat container image, which already includes `openjdk-8`, so there's no need now to install it when mounting.