### PR TITLE
Set daily deployments

### DIFF
--- a/.github/workflows/deploy_instance.yml
+++ b/.github/workflows/deploy_instance.yml
@@ -1,6 +1,8 @@
 name: Deployment of TryArrow in AWS
 
 on:
+  schedule:
+    - cron: "0 7 * * *"
   push:
     branches:
     - master


### PR DESCRIPTION
* Set the Try Arrow deployment to be triggered daily through its GitHub Action, and the `schedule` feature:

  https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule