### PR TITLE
Add missing repositories

### DIFF
--- a/arrow/0.11.0/build.gradle
+++ b/arrow/0.11.0/build.gradle
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ 
+repositories {
+    maven { url 'https://dl.bintray.com/jannis/kotlin-pretty' }
+    maven { url 'https://dl.bintray.com/jannis/kparsec' }
+}
 
 dependencies {
     library group: 'io.arrow-kt', name: 'arrow-ank', version: '0.11.0'

--- a/arrow/1.0.0-SNAPSHOT/build.gradle
+++ b/arrow/1.0.0-SNAPSHOT/build.gradle
@@ -16,6 +16,8 @@
 
 repositories {
     maven { url "https://oss.jfrog.org/artifactory/oss-snapshot-local/" }
+    maven { url 'https://dl.bintray.com/jannis/kotlin-pretty' }
+    maven { url 'https://dl.bintray.com/jannis/kparsec' }
 }
 
 dependencies {


### PR DESCRIPTION
This pull request fixes the deployment:

```
 Could not resolve all files for configuration ':arrow:0.11.0:library'.
 > Could not find kotlin-pretty:kotlin-pretty:0.5.2.
   Searched in the following locations: 
       https://jcenter.bintray.com/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.pom
       https://jcenter.bintray.com/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.jar
       https://dl.bintray.com/kotlin/kotlin-dev/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.pom
       https://dl.bintray.com/kotlin/kotlin-dev/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.jar
       https://kotlin.bintray.com/kotlin-eap-1.2/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.pom
       https://kotlin.bintray.com/kotlin-eap-1.2/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.jar
       https://repo1.maven.org/maven2/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.pom
       https://repo1.maven.org/maven2/kotlin-pretty/kotlin-pretty/0.5.2/kotlin-pretty-0.5.2.jar
   Required by:
       project :arrow:0.11.0 > io.arrow-kt:arrow-check:0.11.0
 > Could not find kotlin-pretty:kotlin-pretty-ansi:0.5.2.
   Searched in the following locations: 
       https://jcenter.bintray.com/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.pom
       https://jcenter.bintray.com/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.jar
       https://dl.bintray.com/kotlin/kotlin-dev/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.pom
       https://dl.bintray.com/kotlin/kotlin-dev/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.jar
       https://kotlin.bintray.com/kotlin-eap-1.2/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.pom
       https://kotlin.bintray.com/kotlin-eap-1.2/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.jar
       https://repo1.maven.org/maven2/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.pom
       https://repo1.maven.org/maven2/kotlin-pretty/kotlin-pretty-ansi/0.5.2/kotlin-pretty-ansi-0.5.2.jar
   Required by:
       project :arrow:0.11.0 > io.arrow-kt:arrow-check:0.11.0
 4 actionable tasks: 1 executed, 3 up-to-date
 > Could not find kparsec:kparsec:0.2.2. 
   Searched in the following locations: 
       https://jcenter.bintray.com/kparsec/kparsec/0.2.2/kparsec-0.2.2.pom
       https://jcenter.bintray.com/kparsec/kparsec/0.2.2/kparsec-0.2.2.jar
       https://dl.bintray.com/kotlin/kotlin-dev/kparsec/kparsec/0.2.2/kparsec-0.2.2.pom
       https://dl.bintray.com/kotlin/kotlin-dev/kparsec/kparsec/0.2.2/kparsec-0.2.2.jar
       https://kotlin.bintray.com/kotlin-eap-1.2/kparsec/kparsec/0.2.2/kparsec-0.2.2.pom
       https://kotlin.bintray.com/kotlin-eap-1.2/kparsec/kparsec/0.2.2/kparsec-0.2.2.jar
       https://repo1.maven.org/maven2/kparsec/kparsec/0.2.2/kparsec-0.2.2.pom
       https://repo1.maven.org/maven2/kparsec/kparsec/0.2.2/kparsec-0.2.2.jar
   Required by:
       project :arrow:0.11.0 > io.arrow-kt:arrow-check:0.11.0

```