### PR TITLE
Add support for Kotlin 1.4.0

### DIFF
--- a/kotlin.web.demo.common/src/main/resources/compilers-config.json
+++ b/kotlin.web.demo.common/src/main/resources/compilers-config.json
@@ -34,7 +34,14 @@
     "stdlibVersion": "1.3.50",
     "buildType": "Kotlin_1350_Aggregate",
     "build": "1.3.50-release-112",
-    "pluginBuild": "1.3.50-release-IJ2018.3-1",
+    "pluginBuild": "1.3.50-release-IJ2018.3-1"
+  },
+  {
+    "version": "1.4.0",
+    "stdlibVersion": "1.4.0",
+    "buildType": "Kotlin_KotlinRelease_140_IdePluginTests_IdeaUltimate_193",
+    "build": "1.4.0-release-329",
+    "pluginBuild": "1.4.0-release-IJ2019.3-1",
     "latestStable": true
   }
 ]

--- a/versions/1.4.0/build.gradle
+++ b/versions/1.4.0/build.gradle
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+    repositories {
+        maven {
+            url  "https://dl.bintray.com/kotlin/kotlin-dev"
+        }
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0"
+    }
+}
+
+
+plugins {
+    id "com.github.jk1.tcdeps" version "0.15"
+}
+
+apply plugin: "org.jetbrains.kotlin.jvm"
+
+
+repositories {
+    teamcityServer {
+        url = 'https://buildserver.labs.intellij.net/'
+    }
+    maven {
+        url "https://cache-redirector.jetbrains.com/kotlin.bintray.com/kotlin-plugin"
+    }
+}
+
+configurations {
+    kotlinJVM
+    kotlinJS
+    library
+}
+
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile).all {
+    kotlinOptions.freeCompilerArgs += ["-Xskip-metadata-version-check"]
+}
+
+
+dependencies {
+    compile project(":kotlin.web.demo.backend:compilers")
+
+    def root = "$kotlinBuildType:$kotlinBuild:kotlin-plugin-${pluginBuild}.zip!/Kotlin/kotlinc/lib"
+
+    kotlinJVM "org.jetbrains.intellij.deps:trove4j:1.0.20181211"
+    kotlinJVM "org.jetbrains.kotlin:ide-common-ij193:${kotlinBuild}"
+    compile "org.jetbrains.kotlin:ide-common-ij193:${kotlinBuild}"
+
+    kotlinJVM tc("$root/kotlin-compiler.jar")
+    kotlinJVM tc("$root/kotlin-script-runtime.jar")
+    kotlinJVM tc("$root/kotlin-stdlib.jar")
+    kotlinJVM tc("$root/kotlin-stdlib-jdk7.jar")
+    kotlinJVM tc("$root/kotlin-stdlib-jdk8.jar")
+    kotlinJVM tc("$kotlinBuildType:$kotlinBuild:kotlin-plugin-${pluginBuild}.zip!/Kotlin/lib/kotlin-plugin.jar")
+    kotlinJVM tc("$root/kotlin-reflect.jar")
+    kotlinJS tc("$root/kotlin-stdlib-js.jar")
+
+    library tc("$root/kotlin-reflect.jar")
+    library tc("$root/kotlin-stdlib.jar")
+    library tc("$root/kotlin-stdlib-jdk7.jar")
+    library tc("$root/kotlin-stdlib-jdk8.jar")
+    library tc("$root/kotlin-test.jar")
+    library("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9") {
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
+    }
+    /**
+     * ADD DEPENDENCIES TO KOTLIN 1.4.0 COMPILER
+     *
+     * If you want to add some another dependencies to kotlin-compiler you can use 'library' task.
+     *
+     * For example:
+     *
+     * library "your dependency from maven"
+     *
+     * FYI: Pay attention if yor library has got reflections, work with files and etc
+     * Please configure the 'executors.policy.template' in web-demo-backend.
+     * @see <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html">Java Security Police</a>
+     *
+     * HOW TO SET Java Security Police in 'executors.policy.template'
+     *
+     * If you want to add own dependency please use marker @WRAPPERS_LIB@
+     *
+     * For example:
+     *
+     * grant codeBase "file:@WRAPPERS_LIB@/junit-4.12.jar" {
+     *      permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+     *      permission java.lang.RuntimePermission "setIO";
+     *      permission java.io.FilePermission "<<ALL FILES>>", "read";
+     *      permission java.lang.RuntimePermission "accessDeclaredMembers";
+     * };
+     */
+
+    compile fileTree(dir: projectDir.toString() + File.separator + "kotlin", include: '*.jar')
+}
+
+task copyKotlinLibs(type: Copy) {
+    from configurations.kotlinJVM
+    into projectDir.toString() + File.separator + "kotlin"
+}
+

--- a/versions/1.4.0/gradle.properties
+++ b/versions/1.4.0/gradle.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2000-2019 JetBrains s.r.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kotlinBuildType=Kotlin_KotlinRelease_140_IdePluginTests_IdeaUltimate_193
+kotlinBuild=1.4.0-release-329
+pluginBuild=1.4.0-release-IJ2019.3-1
+stdlibVersion=1.4.0

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/idea/DummyCodeStyleManager.java
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/idea/DummyCodeStyleManager.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.webdemo.kotlin.idea;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.ChangedRangesInfo;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.codeStyle.Indent;
+import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.ThrowableRunnable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public class DummyCodeStyleManager extends CodeStyleManager {
+    @NotNull
+    @Override
+    public Project getProject() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NotNull
+    @Override
+    public PsiElement reformat(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+        return psiElement;
+    }
+
+    @NotNull
+    @Override
+    public PsiElement reformat(@NotNull PsiElement psiElement, boolean b) throws IncorrectOperationException {
+        return psiElement;
+    }
+
+    @Override
+    public PsiElement reformatRange(@NotNull PsiElement psiElement, int i, int i1) throws IncorrectOperationException {
+        return psiElement;
+    }
+
+    @Override
+    public PsiElement reformatRange(@NotNull PsiElement psiElement, int i, int i1, boolean b) throws IncorrectOperationException {
+        return psiElement;
+    }
+
+    @Override
+    public void reformatText(@NotNull PsiFile psiFile, int i, int i1) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public void reformatText(@NotNull PsiFile psiFile, @NotNull Collection<TextRange> collection) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public void reformatTextWithContext(@NotNull PsiFile psiFile, @NotNull ChangedRangesInfo changedRangesInfo) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public void reformatTextWithContext(@NotNull PsiFile psiFile, @NotNull Collection<TextRange> collection) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public void adjustLineIndent(@NotNull PsiFile psiFile, TextRange textRange) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public int adjustLineIndent(@NotNull PsiFile psiFile, int i) throws IncorrectOperationException {
+        return i;
+    }
+
+    @Override
+    public int adjustLineIndent(@NotNull Document document, int i) {
+        return i;
+    }
+
+    @Override
+    public boolean isLineToBeIndented(@NotNull PsiFile psiFile, int i) {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public String getLineIndent(@NotNull PsiFile psiFile, int i) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getLineIndent(@NotNull Document document, int i) {
+        return null;
+    }
+
+    @Override
+    public Indent getIndent(String s, FileType fileType) {
+        return null;
+    }
+
+    @Override
+    public String fillIndent(Indent indent, FileType fileType) {
+        return null;
+    }
+
+    @Override
+    public Indent zeroIndent() {
+        return null;
+    }
+
+    @Override
+    public void reformatNewlyAddedElement(@NotNull ASTNode astNode, @NotNull ASTNode astNode1) throws IncorrectOperationException {
+
+    }
+
+    @Override
+    public boolean isSequentialProcessingAllowed() {
+        return false;
+    }
+
+    @Override
+    public void performActionWithFormatterDisabled(Runnable runnable) {
+        runnable.run();
+    }
+
+    @Override
+    public <T extends Throwable> void performActionWithFormatterDisabled(ThrowableRunnable<T> throwableRunnable) throws T {
+        throwableRunnable.run();
+    }
+
+    @Override
+    public <T> T performActionWithFormatterDisabled(Computable<T> computable) {
+        return computable.compute();
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/JetPsiFactoryUtil.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/JetPsiFactoryUtil.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+package org.jetbrains.webdemo.kotlin.impl
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.CharsetToolkit
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.impl.PsiFileFactoryImpl
+import com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtFile
+
+object JetPsiFactoryUtil {
+
+    fun createFile(project: Project, name: String, text: String): KtFile {
+        val nameWithExtension = if (name.endsWith(".kt")) name else "$name.kt"
+        val virtualFile = LightVirtualFile(nameWithExtension, KotlinLanguage.INSTANCE, text)
+        virtualFile.charset = CharsetToolkit.UTF8_CHARSET
+        return (PsiFileFactory.getInstance(project) as PsiFileFactoryImpl).trySetupPsiForFile(virtualFile, KotlinLanguage.INSTANCE, true, false) as KtFile
+    }
+
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/KotlinResolutionFacade.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/KotlinResolutionFacade.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+package org.jetbrains.webdemo.kotlin.impl
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.container.ComponentProvider
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.idea.resolve.ResolutionFacade
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
+
+import org.jetbrains.webdemo.kotlin.impl.environment.EnvironmentManager
+
+class KotlinResolutionFacade(private val provider: ComponentProvider?, override val moduleDescriptor: ModuleDescriptor) : ResolutionFacade {
+
+    override fun <T : Any> getFrontendService(element: PsiElement, serviceClass: Class<T>): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T : Any> getFrontendService(serviceClass: Class<T>): T {
+        return if (provider == null)
+            throw IllegalArgumentException("Provider is null in 'getFrontendService'")
+        else provider.resolve(serviceClass)!!.getValue() as T
+    }
+
+    override fun <T : Any> getFrontendService(moduleDescriptor: ModuleDescriptor, serviceClass: Class<T>): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T : Any> getIdeService(serviceClass: Class<T>): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T : Any> tryGetFrontendService(element: PsiElement, serviceClass: Class<T>): T? {
+        throw UnsupportedOperationException()
+    }
+
+    override val project: Project
+        get() = EnvironmentManager.getEnvironment().project
+
+    override fun analyze(element: KtElement, bodyResolveMode: BodyResolveMode): BindingContext {
+        throw UnsupportedOperationException()
+    }
+
+    override fun analyzeWithAllCompilerChecks(elements: Collection<KtElement>): AnalysisResult {
+        throw UnsupportedOperationException()
+    }
+
+    override fun resolveToDescriptor(declaration: KtDeclaration, bodyResolveMode: BodyResolveMode): DeclarationDescriptor {
+        throw UnsupportedOperationException()
+    }
+
+    override fun analyze(elements: Collection<KtElement>, bodyResolveMode: BodyResolveMode): BindingContext {
+        throw UnsupportedOperationException()
+    }
+
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/KotlinWrapperImpl.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/KotlinWrapperImpl.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("PRE_RELEASE_CLASS")
+
+package org.jetbrains.webdemo.kotlin.impl
+
+
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.webdemo.KotlinVersionConfig
+import org.jetbrains.webdemo.kotlin.KotlinWrapper
+import org.jetbrains.webdemo.kotlin.KotlinWrappersManager
+import org.jetbrains.webdemo.kotlin.datastructures.*
+import org.jetbrains.webdemo.kotlin.impl.analyzer.ErrorAnalyzer
+import org.jetbrains.webdemo.kotlin.impl.compiler.KotlinCompilerWrapper
+import org.jetbrains.webdemo.kotlin.impl.completion.CompletionProvider
+import org.jetbrains.webdemo.kotlin.impl.converter.WebDemoJavaToKotlinConverter
+import org.jetbrains.webdemo.kotlin.impl.environment.EnvironmentManager
+import org.jetbrains.webdemo.kotlin.impl.translator.WebDemoTranslatorFacade
+import java.nio.file.Path
+import java.util.*
+
+class KotlinWrapperImpl : KotlinWrapper {
+    private lateinit var jarsFolder: Path
+    private var kotlinVersion: String? = null
+    private var kotlinBuild: String? = null
+    private lateinit var wrapperFolder: Path
+    private lateinit var userLibFolder: Path
+
+    override fun init(javaLibraries: List<Path>, config: KotlinVersionConfig) {
+        this.kotlinVersion = config.version
+        this.kotlinBuild = config.build
+        WrapperLogger.init(kotlinVersion!!)
+        wrapperFolder = KotlinWrappersManager.wrappersDir.resolve(kotlinVersion)
+        jarsFolder = wrapperFolder.resolve("kotlin")
+        userLibFolder = wrapperFolder.resolve("libraries")
+        WrapperSettings.JS_LIB_ROOT = wrapperFolder.resolve("js")
+        val libraries = kotlinLibraries
+        libraries.addAll(javaLibraries)
+        EnvironmentManager.init(libraries)
+    }
+
+    override fun translateJavaToKotlin(javaCode: String): String {
+        return WebDemoJavaToKotlinConverter.getResult(javaCode)
+    }
+
+    override fun getErrors(files: Map<String, String>, isJs: Boolean): Map<String, List<ErrorDescriptor>> {
+        val psiFiles = createPsiFiles(files)
+        val analyzer = ErrorAnalyzer(psiFiles, EnvironmentManager.getEnvironment().project)
+        return analyzer.getAllErrors(isJs)
+    }
+
+    override fun compileKotlinToJS(files: Map<String, String>, args: Array<String>): TranslationResult {
+        val ktFiles = createPsiFiles(files)
+        return WebDemoTranslatorFacade.translateProjectWithCallToMain(ktFiles, args)
+    }
+
+    override fun getCompletionVariants(
+            projectFiles: Map<String, String>, filename: String, line: Int, ch: Int, isJs: Boolean): List<CompletionVariant> {
+        val files = createPsiFiles(projectFiles)
+        val completionProvider = CompletionProvider(files, filename, line, ch)
+        return completionProvider.getResult(isJs)
+    }
+
+    override fun compileCorrectFiles(projectFiles: Map<String, String>, fileName: String?, searchForMain: Boolean): CompilationResult {
+        val files = createPsiFiles(projectFiles)
+        val compilerWrapper = KotlinCompilerWrapper()
+        val environment = EnvironmentManager.getEnvironment()
+        return compilerWrapper.compile(files, environment.project, environment.configuration, fileName!!, searchForMain)
+    }
+
+    /**
+     * Get user jar-libraries from 'libraries' folder
+     * For adding user-library please add dependencies to build.gradle
+     * Use 'library' task for downloading dependency
+     *
+     * @return list of [Path] to library
+     */
+    override fun getKotlinLibraries(): MutableList<Path> {
+        val libraries = ArrayList<Path>()
+        userLibFolder.toFile().listFiles { pathname -> pathname.absolutePath.matches(Regex(".*\\.jar$"))}
+                ?.forEach { libraries.add(it.toPath()) }
+        return libraries
+    }
+
+    override fun getKotlinRuntimeJar(): Path {
+        return userLibFolder.resolve("kotlin-stdlib-$kotlinBuild.jar")
+    }
+
+    override fun getWrapperFolder(): Path? {
+        return wrapperFolder
+    }
+
+    override fun getWrapperVersion(): String? {
+        return kotlinVersion
+    }
+
+    override fun getMethodPositions(classFiles: Map<String, ByteArray>): MethodPositions {
+        val methodPositions = MethodPositions()
+        for (key in classFiles.keys) {
+            methodPositions.addClassMethodPositions(key, MethodsFinder.readClassMethodPositions(classFiles[key]!!, key))
+        }
+        return methodPositions
+    }
+
+    private fun createPsiFiles(files: Map<String, String>): MutableList<KtFile> {
+        return files.keys.mapTo(ArrayList()) { JetPsiFactoryUtil.createFile(EnvironmentManager.getEnvironment().project, it, files[it]!!) }
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/MethodsFinder.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/MethodsFinder.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.webdemo.kotlin.impl
+
+import jdk.internal.org.objectweb.asm.*
+import org.jetbrains.webdemo.kotlin.datastructures.ClassMethodPositions
+import java.util.*
+
+object MethodsFinder {
+    fun readClassMethodPositions(classFile: ByteArray, classFileName: String): ClassMethodPositions {
+        val classReader = ClassReader(classFile)
+        val positions = HashMap<String, Int>()
+
+        val sourceFileName = arrayOfNulls<String>(1)
+
+        classReader.accept(
+                object : ClassVisitor(Opcodes.ASM5) {
+                    override fun visitSource(source: String?, debug: String?) {
+                        sourceFileName[0] = source
+                    }
+
+                    override fun visitMethod(
+                            access: Int, name: String, desc: String?, signature: String?, exceptions: Array<String>?
+                    ): MethodVisitor {
+                        return object : MethodVisitor(Opcodes.ASM5) {
+                            override fun visitLineNumber(line: Int, start: Label) {
+                                var position: Int? = positions[name]
+                                if (position == null || position > line) {
+                                    position = line
+                                }
+                                positions.put(name, position)
+                            }
+                        }
+                    }
+                },
+                0
+        )
+
+        return ClassMethodPositions(
+                sourceFileName[0],
+                classFileName,
+                positions
+        )
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/ResolveUtils.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/ResolveUtils.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("PRE_RELEASE_CLASS")
+
+package org.jetbrains.webdemo.kotlin.impl
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.codegen.ClassBuilderFactories
+import org.jetbrains.kotlin.codegen.state.GenerationState
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.container.*
+import org.jetbrains.kotlin.context.ContextForNewModule
+import org.jetbrains.kotlin.context.ModuleContext
+import org.jetbrains.kotlin.context.ProjectContext
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.frontend.di.configureModule
+import org.jetbrains.kotlin.incremental.components.LookupTracker
+import org.jetbrains.kotlin.js.analyze.TopDownAnalyzerFacadeForJS
+import org.jetbrains.kotlin.js.config.JSConfigurationKeys
+import org.jetbrains.kotlin.js.config.JsConfig
+import org.jetbrains.kotlin.js.resolve.JsPlatformAnalyzerServices
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.platform.TargetPlatformVersion
+import org.jetbrains.kotlin.platform.js.JsPlatforms
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.*
+import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowInfo
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import org.jetbrains.kotlin.resolve.lazy.FileScopeProviderImpl
+import org.jetbrains.kotlin.resolve.lazy.KotlinCodeAnalyzer
+import org.jetbrains.kotlin.resolve.lazy.ResolveSession
+import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProviderFactory
+import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
+import org.jetbrains.webdemo.kotlin.impl.environment.EnvironmentManager
+import java.util.*
+
+object ResolveUtils {
+
+    fun getBindingContext(files: List<KtFile>, project: Project, isJs: Boolean): BindingContext {
+        val result = if (isJs) analyzeFileForJs(files, project) else analyzeFileForJvm(files, project)
+        val analyzeExhaust = result.getFirst()
+        return analyzeExhaust.bindingContext
+    }
+
+    fun getGenerationState(files: List<KtFile>, project: Project, compilerConfiguration: CompilerConfiguration): GenerationState {
+        val analyzeExhaust = analyzeFileForJvm(files, project).getFirst()
+        return GenerationState.Builder(
+                project,
+                ClassBuilderFactories.BINARIES,
+                analyzeExhaust.moduleDescriptor,
+                analyzeExhaust.bindingContext,
+                files,
+                compilerConfiguration
+        ).build()
+    }
+
+    @Synchronized
+    fun analyzeFileForJvm(files: List<KtFile>, project: Project): Pair<AnalysisResult, ComponentProvider> {
+        val environment = EnvironmentManager.getEnvironment()
+        val trace = CliBindingTrace()
+        val configuration = environment.configuration
+
+        val container = TopDownAnalyzerFacadeForJVM.createContainer(
+                environment.project,
+                files,
+                trace,
+                configuration,
+                { globalSearchScope -> environment.createPackagePartProvider(globalSearchScope) },
+                { storageManager, ktFiles -> FileBasedDeclarationProviderFactory(storageManager, ktFiles) }
+        )
+
+        container.getService(LazyTopDownAnalyzer::class.java).analyzeDeclarations(TopDownAnalysisMode.TopLevelDeclarations, files, DataFlowInfo.EMPTY)
+
+        val moduleDescriptor = container.getService(ModuleDescriptor::class.java)
+        for (extension in AnalysisHandlerExtension.getInstances(project)) {
+            val result = extension.analysisCompleted(project, moduleDescriptor, trace, files)
+            if (result != null) break
+        }
+
+        return Pair(
+                AnalysisResult.success(trace.bindingContext, moduleDescriptor),
+                container)
+    }
+
+    @Synchronized
+    fun analyzeFileForJs(files: List<KtFile>, project: Project): Pair<AnalysisResult, ComponentProvider> {
+        val environment = EnvironmentManager.getEnvironment()
+
+        val configuration = environment.configuration.copy()
+        configuration.put(JSConfigurationKeys.LIBRARIES, listOf(WrapperSettings.JS_LIB_ROOT!!.toString()))
+        val config = JsConfig(project, configuration)
+
+        val module = ContextForNewModule(
+                ProjectContext(project, "WED-DEMO-JS"),
+                Name.special("<" + config.moduleId + ">"),
+                JsPlatformAnalyzerServices.builtIns, null
+        )
+        module.setDependencies(computeDependencies(module.module, config))
+
+        val trace = CliBindingTrace()
+
+        val providerFactory = FileBasedDeclarationProviderFactory(module.storageManager, files)
+
+        val analyzerAndProvider = createContainerForTopDownAnalyzerForJs(module, trace, EnvironmentManager.languageVersion, providerFactory)
+
+        return Pair(
+                TopDownAnalyzerFacadeForJS.analyzeFiles(files, config),
+                analyzerAndProvider.second)
+    }
+
+    private fun computeDependencies(module: ModuleDescriptorImpl, config: JsConfig): List<ModuleDescriptorImpl> {
+        val allDependencies = ArrayList<ModuleDescriptorImpl>()
+        allDependencies.add(module)
+        config.moduleDescriptors.mapTo(allDependencies) { it }
+        allDependencies.add(JsPlatformAnalyzerServices.builtIns.builtInsModule)
+        return allDependencies
+    }
+
+    private fun createContainerForTopDownAnalyzerForJs(
+            moduleContext: ModuleContext,
+            bindingTrace: BindingTrace,
+            platformVersion: TargetPlatformVersion,
+            declarationProviderFactory: DeclarationProviderFactory
+    ): Pair<LazyTopDownAnalyzer, ComponentProvider> {
+        val container = composeContainer(
+                "TopDownAnalyzerForJs",
+                JsPlatformAnalyzerServices.platformConfigurator.platformSpecificContainer
+        ) {
+            configureModule(moduleContext, JsPlatforms.defaultJsPlatform, JsPlatformAnalyzerServices, bindingTrace, LanguageVersionSettingsImpl.DEFAULT)
+            useInstance(declarationProviderFactory)
+            registerSingleton(AnnotationResolverImpl::class.java)
+            registerSingleton(FileScopeProviderImpl::class.java)
+
+            CompilerEnvironment.configure(this)
+
+            useInstance(LookupTracker.DO_NOTHING)
+            registerSingleton(ResolveSession::class.java)
+            registerSingleton(LazyTopDownAnalyzer::class.java)
+        }
+
+        container.getService(ModuleDescriptorImpl::class.java).initialize(container.getService(KotlinCodeAnalyzer::class.java).getPackageFragmentProvider())
+
+        return Pair(container.getService(LazyTopDownAnalyzer::class.java), container)
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/WrapperLogger.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/WrapperLogger.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.webdemo.kotlin.impl
+
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+
+object WrapperLogger {
+    private var log: Log? = null
+
+    fun init(kotlinVersion: String) {
+        log = LogFactory.getLog("wrapper-" + kotlinVersion)
+    }
+
+    fun reportException(message: String, e: Throwable) {
+        log!!.error(message, e)
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/WrapperSettings.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/WrapperSettings.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.webdemo.kotlin.impl
+
+import java.nio.file.Path
+
+object WrapperSettings {
+    var JS_LIB_ROOT: Path? = null
+
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/analyzer/ErrorAnalyzer.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/analyzer/ErrorAnalyzer.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+package org.jetbrains.webdemo.kotlin.impl.analyzer
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.diagnostics.Severity
+import org.jetbrains.kotlin.diagnostics.rendering.DefaultErrorMessages
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.webdemo.kotlin.datastructures.ErrorDescriptor
+import org.jetbrains.webdemo.kotlin.datastructures.TextInterval
+import org.jetbrains.webdemo.kotlin.datastructures.TextPosition
+import org.jetbrains.webdemo.kotlin.exceptions.KotlinCoreException
+import org.jetbrains.webdemo.kotlin.impl.ResolveUtils
+import org.jetbrains.webdemo.kotlin.impl.WrapperSettings
+import java.util.*
+
+class ErrorAnalyzer(private val currentPsiFiles: List<KtFile>, private val currentProject: Project) {
+
+    fun getAllErrors(isJs: Boolean): Map<String, List<ErrorDescriptor>> {
+        try {
+            val errors = HashMap<String, List<ErrorDescriptor>>()
+            for (psiFile in currentPsiFiles) {
+                errors.put(psiFile.name, getErrorsByVisitor(psiFile))
+            }
+            val bindingContext = ResolveUtils.getBindingContext(currentPsiFiles, currentProject, isJs)
+            val diagnosticErrors = getErrorsFromDiagnostics(bindingContext.diagnostics.all(), errors)
+            errors.putAll(diagnosticErrors)
+            return errors
+        } catch (e: Throwable) {
+            throw KotlinCoreException(e)
+        }
+
+    }
+
+    fun getErrorsFromDiagnostics(diagnostics: Collection<Diagnostic>, errors: Map<String, List<ErrorDescriptor>>): Map<String, List<ErrorDescriptor>> {
+        val diagnosticErrors: MutableMap<String, List<ErrorDescriptor>> = errors.toMutableMap()
+        try {
+            for (diagnostic in diagnostics) {
+                //fix for errors in js library files
+                val virtualFile = diagnostic.psiFile.virtualFile
+                if (virtualFile == null || virtualFile.presentableUrl.startsWith(WrapperSettings.JS_LIB_ROOT!!.toString())) {
+                    continue
+                }
+                val render = DefaultErrorMessages.render(diagnostic)
+                if (render.contains("This cast can never succeed")) {
+                    continue
+                }
+                if (diagnostic.severity != Severity.INFO) {
+                    val textRangeIterator = diagnostic.textRanges.iterator()
+                    if (!textRangeIterator.hasNext()) {
+                        continue
+                    }
+                    val firstRange = textRangeIterator.next()
+
+                    var className = diagnostic.severity.name
+                    if (!(diagnostic.factory === Errors.UNRESOLVED_REFERENCE) && diagnostic.severity == Severity.ERROR) {
+                        className = "red_wavy_line"
+                    }
+                    val interval = getInterval(firstRange.startOffset, firstRange.endOffset,
+                            diagnostic.psiFile.viewProvider.document!!)
+                    val currentError = diagnosticErrors[diagnostic.psiFile.name]!!.plus(ErrorDescriptor(interval, render, convertSeverity(diagnostic.severity), className))
+                    diagnosticErrors[diagnostic.psiFile.name] = currentError
+                }
+            }
+
+            for (key in diagnosticErrors.keys) {
+                Collections.sort(diagnosticErrors[key], Comparator { o1, o2 ->
+                    when {
+                        o1.interval.start.line > o2.interval.start.line -> return@Comparator 1
+                        o1.interval.start.line < o2.interval.start.line -> return@Comparator -1
+                        o1.interval.start.line == o2.interval.start.line -> when {
+                            o1.interval.start.ch > o2.interval.start.ch -> return@Comparator 1
+                            o1.interval.start.ch < o2.interval.start.ch -> return@Comparator -1
+                            o1.interval.start.ch == o2.interval.start.ch -> return@Comparator 0
+                            else -> {
+                            }
+                        }
+                    }
+                    -1
+                })
+            }
+        } catch (e: Throwable) {
+            throw KotlinCoreException(e)
+        }
+        return diagnosticErrors
+    }
+
+    private fun getErrorsByVisitor(psiFile: PsiFile): List<ErrorDescriptor> {
+        val errorElements = ArrayList<PsiErrorElement>()
+        val visitor = object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                element.acceptChildren(this)
+            }
+
+            override fun visitErrorElement(element: PsiErrorElement) {
+                errorElements.add(element)
+            }
+
+        }
+
+        val errors = ArrayList<ErrorDescriptor>()
+        visitor.visitFile(psiFile)
+        for (errorElement in errorElements) {
+            val start = errorElement.textRange.startOffset
+            val end = errorElement.textRange.endOffset
+            val interval = getInterval(start, end, psiFile.viewProvider.document!!)
+            errors.add(ErrorDescriptor(interval, errorElement.errorDescription,
+                    convertSeverity(Severity.ERROR), "red_wavy_line"))
+        }
+        return errors
+    }
+
+    private fun convertSeverity(severity: Severity): org.jetbrains.webdemo.kotlin.datastructures.Severity {
+        return when (severity) {
+            Severity.ERROR -> org.jetbrains.webdemo.kotlin.datastructures.Severity.ERROR
+            Severity.INFO -> org.jetbrains.webdemo.kotlin.datastructures.Severity.INFO
+            Severity.WARNING -> org.jetbrains.webdemo.kotlin.datastructures.Severity.WARNING
+        }
+    }
+
+    private fun getInterval(start: Int, end: Int, currentDocument: Document): TextInterval {
+        val lineNumberForElementStart = currentDocument.getLineNumber(start)
+        val lineNumberForElementEnd = currentDocument.getLineNumber(end)
+        var charNumberForElementStart = start - currentDocument.getLineStartOffset(lineNumberForElementStart)
+        var charNumberForElementEnd = end - currentDocument.getLineStartOffset(lineNumberForElementStart)
+        if (start == end && lineNumberForElementStart == lineNumberForElementEnd) {
+            charNumberForElementStart--
+            if (charNumberForElementStart < 0) {
+                charNumberForElementStart++
+                charNumberForElementEnd++
+            }
+        }
+        val startPosition = TextPosition(lineNumberForElementStart, charNumberForElementStart)
+        val endPosition = TextPosition(lineNumberForElementEnd, charNumberForElementEnd)
+        return TextInterval(startPosition, endPosition)
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/compiler/KotlinCompilerWrapper.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/compiler/KotlinCompilerWrapper.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+package org.jetbrains.webdemo.kotlin.impl.compiler
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.codegen.KotlinCodegenFacade
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.idea.MainFunctionDetector
+import org.jetbrains.kotlin.load.kotlin.PackagePartClassUtils
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.webdemo.kotlin.datastructures.CompilationResult
+import org.jetbrains.webdemo.kotlin.exceptions.KotlinCompileException
+import org.jetbrains.webdemo.kotlin.impl.ResolveUtils
+import java.util.*
+
+class KotlinCompilerWrapper {
+    fun compile(currentPsiFiles: List<KtFile>, currentProject: Project, configuration: CompilerConfiguration, fileName: String, searchForMain: Boolean): CompilationResult {
+        try {
+            val generationState = ResolveUtils.getGenerationState(currentPsiFiles, currentProject, configuration)
+            val mainClass = findMainClass(generationState.bindingContext, currentPsiFiles, fileName, searchForMain)
+            KotlinCodegenFacade.compileCorrectFiles(generationState)
+            val factory = generationState.factory
+            val files = HashMap<String, ByteArray>()
+            for (file in factory.asList()) {
+                files.put(file.relativePath, file.asByteArray())
+            }
+            return CompilationResult(files, mainClass)
+        } catch (e: Throwable) {
+            throw KotlinCompileException(e)
+        }
+
+    }
+
+    private fun findMainClass(bindingContext: BindingContext, files: List<KtFile>, fileName: String, searchForMain: Boolean): String {
+        val mainFunctionDetector = MainFunctionDetector(bindingContext, LanguageVersionSettingsImpl.DEFAULT)
+        files
+                .filter { it.name.contains(fileName) && (!searchForMain || mainFunctionDetector.hasMain(it.declarations)) }
+                .forEach { return getMainClassName(it) }
+        for (file in files) {
+            if (mainFunctionDetector.hasMain(file.declarations)) {
+                return getMainClassName(file)
+            }
+        }
+        return getMainClassName(files.iterator().next())
+    }
+
+    private fun getMainClassName(file: KtFile): String {
+        return PackagePartClassUtils.getPackagePartFqName(file.packageFqName, file.name).asString()
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/completion/CompletionProvider.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/completion/CompletionProvider.kt
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+package org.jetbrains.webdemo.kotlin.impl.completion
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.TokenSet
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
+import org.jetbrains.kotlin.descriptors.impl.TypeParameterDescriptorImpl
+import org.jetbrains.kotlin.idea.codeInsight.ReferenceVariantsHelper
+import org.jetbrains.kotlin.idea.core.isVisible
+import org.jetbrains.kotlin.idea.imports.importableFqName
+import org.jetbrains.kotlin.idea.util.IdeDescriptorRenderers
+import org.jetbrains.kotlin.idea.util.getResolutionScope
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.renderer.ClassifierNamePolicy
+import org.jetbrains.kotlin.renderer.ParameterNameRenderingPolicy
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.LexicalScope
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.asFlexibleType
+import org.jetbrains.kotlin.types.expressions.KotlinTypeInfo
+import org.jetbrains.kotlin.types.isFlexible
+import org.jetbrains.webdemo.kotlin.datastructures.CompletionVariant
+import org.jetbrains.webdemo.kotlin.exceptions.KotlinCoreException
+import org.jetbrains.webdemo.kotlin.impl.JetPsiFactoryUtil
+import org.jetbrains.webdemo.kotlin.impl.KotlinResolutionFacade
+import org.jetbrains.webdemo.kotlin.impl.ResolveUtils
+import java.beans.PropertyDescriptor
+import java.util.*
+
+class CompletionProvider(private val psiFiles: MutableList<KtFile>, filename: String, private val lineNumber: Int, private val charNumber: Int) {
+    private val NUMBER_OF_CHAR_IN_COMPLETION_NAME = 40
+    private val NUMBER_OF_CHAR_IN_TAIL = 60
+    private val currentProject: Project
+    private var currentPsiFile: KtFile? = null
+    private var currentDocument: Document? = null
+    private var caretPositionOffset: Int = 0
+
+    private val expressionForScope: PsiElement?
+        get() {
+            var element = currentPsiFile!!.findElementAt(caretPositionOffset)
+            while (element !is KtExpression && element != null) {
+                element = element.parent
+            }
+            return element
+        }
+
+    init {
+        psiFiles
+                .filter { it.name == filename }
+                .forEach { currentPsiFile = it }
+        this.currentProject = currentPsiFile!!.project
+        this.currentDocument = currentPsiFile!!.viewProvider.document
+    }
+
+    @Synchronized
+    fun getResult(isJs: Boolean): List<CompletionVariant> {
+        try {
+            addExpressionAtCaret()
+            val resolveResult = if (!isJs)
+                ResolveUtils.analyzeFileForJvm(psiFiles, currentProject)
+            else
+                ResolveUtils.analyzeFileForJs(psiFiles, currentProject)
+
+            val analysisResult = resolveResult.first
+            val containerProvider = resolveResult.second
+            val bindingContext = analysisResult.bindingContext
+            val moduleDescriptor = analysisResult.moduleDescriptor
+
+            val element = expressionForScope as? KtElement ?: return emptyList()
+            var descriptors: Collection<DeclarationDescriptor>? = null
+            var isTipsManagerCompletion = true
+            val resolutionFacade = KotlinResolutionFacade(containerProvider, moduleDescriptor)
+            val inDescriptor: DeclarationDescriptor = element.getResolutionScope(bindingContext, resolutionFacade).ownerDescriptor
+
+            val helper = ReferenceVariantsHelper(
+                    bindingContext,
+                    resolutionFacade,
+                    analysisResult.moduleDescriptor,
+                    VisibilityFilter(inDescriptor, bindingContext, element, resolutionFacade),
+                    emptySet()
+            )
+
+            if (element is KtSimpleNameExpression) {
+                descriptors = helper.getReferenceVariants(element, DescriptorKindFilter.ALL, NAME_FILTER, true, true, true, null)
+            } else if (element.parent is KtSimpleNameExpression) {
+                descriptors = helper.getReferenceVariants(element.parent as KtSimpleNameExpression, DescriptorKindFilter.ALL, NAME_FILTER, true, true, true, null)
+            } else {
+                isTipsManagerCompletion = false
+                val resolutionScope: LexicalScope?
+                val parent = element.parent
+                if (parent is KtQualifiedExpression) {
+                    val receiverExpression = parent.receiverExpression
+
+                    val expressionType = bindingContext.get<KtExpression, KotlinTypeInfo>(BindingContext.EXPRESSION_TYPE_INFO, receiverExpression)!!.type
+                    resolutionScope = bindingContext.get<KtElement, LexicalScope>(BindingContext.LEXICAL_SCOPE, receiverExpression)
+
+                    if (expressionType != null && resolutionScope != null) {
+                        descriptors = expressionType.memberScope.getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.ALL_NAME_FILTER)
+                    }
+                } else {
+                    resolutionScope = bindingContext.get<KtElement, LexicalScope>(BindingContext.LEXICAL_SCOPE, element as KtExpression)
+                    if (resolutionScope != null) {
+                        descriptors = resolutionScope.getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.ALL_NAME_FILTER)
+                    } else {
+                        return emptyList()
+                    }
+                }
+            }
+
+            val result = ArrayList<CompletionVariant>()
+
+            if (descriptors != null) {
+                var prefix: String
+                prefix = if (!isTipsManagerCompletion) {
+                    element.parent.text
+                } else {
+                    element.text
+                }
+                prefix = prefix.substringBefore("IntellijIdeaRulezzz", prefix)
+                if (prefix.endsWith(".")) {
+                    prefix = ""
+                }
+
+                if (descriptors !is ArrayList<*>) {
+                    descriptors = ArrayList(descriptors)
+                }
+
+                (descriptors as ArrayList<DeclarationDescriptor>?)?.sortWith(Comparator { d1, d2 ->
+                    val d1PresText = getPresentableText(d1)
+                    val d2PresText = getPresentableText(d2)
+                    (d1PresText.getFirst() + d1PresText.getSecond()).compareTo(d2PresText.getFirst() + d2PresText.getSecond(), ignoreCase = true)
+                })
+
+                for (descriptor in descriptors) {
+                    val presentableText = getPresentableText(descriptor, element.isCallableReference())
+
+                    val fullName = formatName(presentableText.getFirst(), NUMBER_OF_CHAR_IN_COMPLETION_NAME)
+                    var completionText = fullName
+                    var position = completionText.indexOf('(')
+                    if (position != -1) {
+                        //If this is a string with a package after
+                        if (completionText[position - 1] == ' ') {
+                            position -= 2
+                        }
+                        //if this is a method without args
+                        if (completionText[position + 1] == ')') {
+                            position++
+                        }
+                        completionText = completionText.substring(0, position + 1)
+                    }
+                    position = completionText.indexOf(":")
+                    if (position != -1) {
+                        completionText = completionText.substring(0, position - 1)
+                    }
+
+                    if (prefix.isEmpty() || fullName.startsWith(prefix)) {
+                        val completionVariant = CompletionVariant(completionText, fullName,
+                                formatName(presentableText.getSecond(), NUMBER_OF_CHAR_IN_TAIL),
+                                getIconFromDescriptor(descriptor))
+                        result.add(completionVariant)
+                    }
+                }
+
+                result.addAll(keywordsCompletionVariants(KtTokens.KEYWORDS, prefix))
+                result.addAll(keywordsCompletionVariants(KtTokens.SOFT_KEYWORDS, prefix))
+            }
+
+            return result
+        } catch (e: Throwable) {
+            throw KotlinCoreException(e)
+        }
+
+    }
+
+    private fun getIconFromDescriptor(descriptor: DeclarationDescriptor): String {
+        return if (descriptor is FunctionDescriptor) {
+            "method"
+        } else if (descriptor is PropertyDescriptor || descriptor is LocalVariableDescriptor) {
+            "property"
+        } else if (descriptor is ClassDescriptor) {
+            "class"
+        } else if (descriptor is PackageFragmentDescriptor || descriptor is PackageViewDescriptor) {
+            "package"
+        } else if (descriptor is ValueParameterDescriptor) {
+            "genericValue"
+        } else if (descriptor is TypeParameterDescriptorImpl) {
+            "class"
+        } else {
+            ""
+        }
+    }
+
+    private fun formatName(builder: String, symbols: Int): String {
+        return if (builder.length > symbols) {
+            builder.substring(0, symbols) + "..."
+        } else builder
+    }
+
+    private fun addExpressionAtCaret() {
+        caretPositionOffset = getOffsetFromLineAndChar(lineNumber, charNumber)
+        val text = currentPsiFile!!.text
+        if (caretPositionOffset != 0) {
+            val buffer = StringBuilder(text.substring(0, caretPositionOffset))
+            buffer.append("IntellijIdeaRulezzz ")
+            buffer.append(text.substring(caretPositionOffset))
+            psiFiles.remove(currentPsiFile!!)
+            currentPsiFile = JetPsiFactoryUtil.createFile(currentProject, currentPsiFile!!.name, buffer.toString())
+            psiFiles.add(currentPsiFile!!)
+            currentDocument = currentPsiFile!!.viewProvider.document
+        }
+    }
+
+    private fun getOffsetFromLineAndChar(line: Int, charNumber: Int): Int {
+        val lineStart = currentDocument!!.getLineStartOffset(line)
+        return lineStart + charNumber
+    }
+
+    private fun keywordsCompletionVariants(keywords: TokenSet, prefix: String): List<CompletionVariant> {
+        return keywords.types
+                .map { (it as KtKeywordToken).value }
+                .filter { it.startsWith(prefix) }
+                .mapTo(ArrayList()) { CompletionVariant(it, it, "", "") }
+    }
+
+
+    private val RENDERER = IdeDescriptorRenderers.SOURCE_CODE.withOptions {
+        classifierNamePolicy = ClassifierNamePolicy.SHORT
+        typeNormalizer = IdeDescriptorRenderers.APPROXIMATE_FLEXIBLE_TYPES
+        parameterNameRenderingPolicy = ParameterNameRenderingPolicy.NONE
+        typeNormalizer = { kotlinType: KotlinType ->
+            if (kotlinType.isFlexible()) {
+                kotlinType.asFlexibleType().upperBound
+            } else kotlinType
+        }
+    }
+
+    // This code is a fragment of org.jetbrains.kotlin.idea.completion.CompletionSession from Kotlin IDE Plugin
+    // with a few simplifications which were possible because webdemo has very restricted environment (and well,
+    // because requirements on compeltion' quality in web-demo are lower)
+    private inner class VisibilityFilter(
+            private val inDescriptor: DeclarationDescriptor,
+            private val bindingContext: BindingContext,
+            private val element: KtElement,
+            private val resolutionFacade: KotlinResolutionFacade
+    ): (DeclarationDescriptor) -> Boolean {
+        override fun invoke(descriptor: DeclarationDescriptor): Boolean {
+            if (descriptor is TypeParameterDescriptor && !isTypeParameterVisible(descriptor)) return false
+
+            if (descriptor is DeclarationDescriptorWithVisibility) {
+                return descriptor.isVisible(element, null, bindingContext, resolutionFacade)
+            }
+
+            if (descriptor.isInternalImplementationDetail()) return false
+
+            return true
+        }
+
+        private fun isTypeParameterVisible(typeParameter: TypeParameterDescriptor): Boolean {
+            val owner = typeParameter.containingDeclaration
+            var parent: DeclarationDescriptor? = inDescriptor
+            while (parent != null) {
+                if (parent == owner) return true
+                if (parent is ClassDescriptor && !parent.isInner) return false
+                parent = parent.containingDeclaration
+            }
+            return true
+        }
+
+        private fun DeclarationDescriptor.isInternalImplementationDetail(): Boolean =
+                importableFqName?.asString() in excludedFromCompletion
+    }
+
+    private val NAME_FILTER = { name: Name ->
+        !name.isSpecial
+    }
+
+    // see DescriptorLookupConverter.createLookupElement
+    private fun getPresentableText(
+            descriptor: DeclarationDescriptor,
+            isCallableReferenceCompletion: Boolean = false
+    ): Pair<String, String> {
+        var presentableText = if (descriptor is ConstructorDescriptor)
+            descriptor.constructedClass.name.asString()
+        else
+            descriptor.name.asString()
+        var typeText = ""
+        var tailText = ""
+
+        if (descriptor is FunctionDescriptor) {
+            val returnType = descriptor.returnType
+            typeText = if (returnType != null) RENDERER.renderType(returnType) else ""
+
+            if (!isCallableReferenceCompletion)
+                presentableText += RENDERER.renderFunctionParameters(descriptor)
+
+            val extensionFunction = descriptor.extensionReceiverParameter != null
+            val containingDeclaration = descriptor.containingDeclaration
+            if (containingDeclaration != null && extensionFunction) {
+                tailText += " for " + RENDERER.renderType(descriptor.extensionReceiverParameter!!.type)
+                tailText += " in " + DescriptorUtils.getFqName(containingDeclaration)
+            }
+        } else if (descriptor is VariableDescriptor) {
+            val outType = descriptor.type
+            typeText = RENDERER.renderType(outType)
+        } else if (descriptor is ClassDescriptor) {
+            val declaredIn = descriptor.containingDeclaration
+            tailText = " (" + DescriptorUtils.getFqName(declaredIn) + ")"
+        } else {
+            typeText = RENDERER.render(descriptor)
+        }
+
+        return if (typeText.isEmpty()) {
+            Pair(presentableText, tailText)
+        } else {
+            Pair(presentableText, typeText)
+        }
+    }
+
+    private fun KtElement.isCallableReference() =
+            parent is KtCallableReferenceExpression && this == (parent as KtCallableReferenceExpression).callableReference
+
+    companion object {
+        private val excludedFromCompletion: List<String> = listOf(
+                "kotlin.jvm.internal",
+                "kotlin.coroutines.experimental.intrinsics",
+                "kotlin.coroutines.intrinsics",
+                "kotlin.coroutines.experimental.jvm.internal",
+                "kotlin.coroutines.jvm.internal",
+                "kotlin.reflect.jvm.internal"
+        )
+    }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/converter/WebDemoJavaToKotlinConverter.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/converter/WebDemoJavaToKotlinConverter.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+
+package org.jetbrains.webdemo.kotlin.impl.converter
+
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.psi.*
+import org.jetbrains.kotlin.j2k.ConverterSettings
+import org.jetbrains.kotlin.j2k.EmptyJavaToKotlinServices
+import org.jetbrains.kotlin.j2k.JavaToKotlinTranslator
+import org.jetbrains.kotlin.j2k.OldJavaToKotlinConverter
+import org.jetbrains.webdemo.kotlin.impl.ResolveUtils
+import org.jetbrains.webdemo.kotlin.impl.environment.EnvironmentManager
+import java.lang.reflect.InvocationTargetException
+import java.util.*
+
+object WebDemoJavaToKotlinConverter {
+    fun getResult(code: String): String {
+        val project = EnvironmentManager.getEnvironment().project
+        val converter = OldJavaToKotlinConverter(
+                project,
+                ConverterSettings.defaultSettings,
+                EmptyJavaToKotlinServices)
+        val instance = PsiElementFactory.SERVICE.getInstance(project)
+
+        val javaFile = PsiFileFactory.getInstance(project).createFileFromText("test.java", JavaLanguage.INSTANCE, code)
+
+        //To create a module
+        ResolveUtils.getBindingContext(arrayListOf(), project, false)
+
+        var inputElements: List<PsiElement>? = if (javaFile.children.any { it is PsiClass }) listOf<PsiElement>(javaFile) else null
+
+        if (inputElements == null) {
+            val psiClass = instance.createClassFromText(code, javaFile)
+            var errorsFound = false
+            for (element in psiClass.children) {
+                if (element is PsiErrorElement) {
+                    errorsFound = true
+                }
+            }
+            if (!errorsFound) {
+                inputElements = Arrays.asList(*psiClass.children)
+            }
+        }
+
+        if (inputElements == null) {
+            val codeBlock = instance.createCodeBlockFromText("{$code}", javaFile)
+            val childrenWithoutBraces = Arrays.copyOfRange(codeBlock.children, 1, codeBlock.children.size - 1)
+            inputElements = Arrays.asList(*childrenWithoutBraces)
+        }
+
+        val resultFormConverter = converter.elementsToKotlin(inputElements!!).results
+        var textResult = ""
+        resultFormConverter
+                .asSequence()
+                .filterNotNull()
+                .forEach { it -> textResult = textResult + it.text + "\n" }
+        textResult = prettify(textResult)
+        return textResult
+    }
+
+    private fun prettify(code: String): String {
+        try {
+            val method = JavaToKotlinTranslator.javaClass.getDeclaredMethod("prettify", String::class.java)
+            method.isAccessible = true
+            return method.invoke(JavaToKotlinTranslator, code) as String
+        } catch (e: NoSuchMethodException) {
+            throw RuntimeException(e)
+        } catch (e: IllegalAccessException) {
+            throw RuntimeException(e)
+        } catch (e: InvocationTargetException) {
+            throw RuntimeException(e)
+        }
+
+    }
+
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/environment/EnvironmentManager.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/environment/EnvironmentManager.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("PRE_RELEASE_CLASS")
+
+package org.jetbrains.webdemo.kotlin.impl.environment
+
+import com.google.common.collect.Lists
+import com.intellij.codeInsight.ContainerProvider
+import com.intellij.codeInsight.NullableNotNullManager
+import com.intellij.codeInsight.runner.JavaMainMethodProvider
+import com.intellij.core.CoreApplicationEnvironment
+import com.intellij.mock.MockProject
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.Extensions
+import com.intellij.openapi.extensions.ExtensionsArea
+import com.intellij.openapi.fileTypes.FileTypeExtensionPoint
+import com.intellij.openapi.fileTypes.FileTypeRegistry
+import com.intellij.openapi.util.Getter
+import com.intellij.psi.FileContextProvider
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.augment.PsiAugmentProvider
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.compiled.ClassFileDecompilers
+import com.intellij.psi.impl.compiled.ClsCustomNavigationPolicy
+import com.intellij.psi.meta.MetaDataContributor
+import com.intellij.psi.stubs.BinaryFileStubBuilders
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.js.config.JSConfigurationKeys
+import org.jetbrains.kotlin.platform.TargetPlatformVersion
+import org.jetbrains.kotlin.utils.PathUtil
+import org.jetbrains.webdemo.CommonSettings
+import org.jetbrains.webdemo.kotlin.idea.DummyCodeStyleManager
+import java.io.File
+import java.lang.reflect.InvocationTargetException
+import java.nio.file.Path
+
+object EnvironmentManager {
+  private var registry: Getter<FileTypeRegistry>? = null
+  private var environment: KotlinCoreEnvironment? = null
+  private val disposable = Disposable { }
+
+  /**
+   * This list allows to configure behavior of webdemo compiler. Its effect is equivalent
+   * to passing this list of string to CLI compiler.
+   *
+   * See [org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments] and
+   * [org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments] for list of possible flags
+   */
+  private val additionalCompilerArguments: List<String> = listOf(
+    "-Xuse-experimental=kotlin.Experimental",
+    "-Xuse-experimental=kotlin.ExperimentalStdlibApi",
+    "-Xuse-experimental=kotlin.time.ExperimentalTime",
+    "-Xuse-experimental=kotlin.ExperimentalUnsignedTypes",
+    "-Xuse-experimental=kotlin.contracts.ExperimentalContracts",
+    "-Xuse-experimental=kotlin.experimental.ExperimentalTypeInference",
+    "-XXLanguage:+InlineClasses"
+  )
+
+  val languageVersion: TargetPlatformVersion
+    get() = TargetPlatformVersion.NoVersion
+
+  fun init(libraries: List<Path>) {
+    environment = createEnvironment(libraries)
+  }
+
+  fun reinitializeJavaEnvironment() {
+    try {
+      val method = environment!!.javaClass.getDeclaredMethod("getApplicationEnvironment")
+      method.isAccessible = true
+      val applicationEnvironment = method.invoke(environment) as CoreApplicationEnvironment
+
+      ApplicationManager.setApplication(
+        applicationEnvironment.application,
+        registry!!,
+        disposable
+      )
+    }
+    catch (e: NoSuchMethodException) {
+      throw RuntimeException(e)
+    }
+    catch (e: IllegalAccessException) {
+      throw RuntimeException(e)
+    }
+    catch (e: InvocationTargetException) {
+      throw RuntimeException(e)
+    }
+
+  }
+
+  fun getEnvironment(): KotlinCoreEnvironment {
+    if (environment == null) {
+      throw IllegalStateException("Environment should be initialized before")
+    }
+    return environment!!
+  }
+
+  private fun createEnvironment(libraries: List<Path>): KotlinCoreEnvironment {
+    val arguments = K2JVMCompilerArguments()
+    parseCommandLineArguments(additionalCompilerArguments, arguments)
+    val configuration = CompilerConfiguration()
+    configuration.addJvmClasspathRoots(getClasspath(arguments, libraries))
+    configuration.put(JVMConfigurationKeys.DISABLE_PARAM_ASSERTIONS, arguments.noParamAssertions)
+    configuration.put(JVMConfigurationKeys.DISABLE_CALL_ASSERTIONS, arguments.noCallAssertions)
+    configuration.put(JVMConfigurationKeys.JDK_HOME, File(CommonSettings.JAVA_HOME))
+    configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+    configuration.put(CommonConfigurationKeys.MODULE_NAME, "kotlinWebDemo")
+    configuration.put(JSConfigurationKeys.TYPED_ARRAYS_ENABLED, true)
+    configuration.languageVersionSettings =
+      arguments.toLanguageVersionSettings(configuration[CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY]!!)
+    val environment = KotlinCoreEnvironment.createForTests(disposable, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+    val project = environment.project as MockProject
+    project.registerService(NullableNotNullManager::class.java, object : NullableNotNullManager(project) {
+      override fun setInstrumentedNotNulls(p0: MutableList<String>) {}
+      override fun getInstrumentedNotNulls(): MutableList<String> {
+        return mutableListOf()
+      }
+
+      override fun setNullables(vararg p0: String?) {}
+      override fun getDefaultNotNull(): String {
+        return ""
+      }
+
+      override fun getNotNulls(): MutableList<String> {
+        return mutableListOf()
+      }
+
+      override fun getDefaultNullable(): String {
+        return ""
+      }
+
+      override fun setDefaultNotNull(p0: String) {}
+      override fun setNotNulls(vararg p0: String?) {}
+      override fun getNullables(): MutableList<String> {
+        return mutableListOf()
+      }
+
+      override fun setDefaultNullable(p0: String) {}
+      override fun isNullable(owner: PsiModifierListOwner, checkBases: Boolean): Boolean {
+        return false
+      }
+
+      override fun isNotNull(owner: PsiModifierListOwner, checkBases: Boolean): Boolean {
+        return true
+      }
+    })
+    project.registerService(CodeStyleManager::class.java, DummyCodeStyleManager())
+    registerExtensionPoints(Extensions.getRootArea())
+    registry = FileTypeRegistry.ourInstanceGetter
+    return environment
+  }
+
+  private fun registerExtensionPoints(area: ExtensionsArea) {
+    CoreApplicationEnvironment.registerExtensionPoint(area, BinaryFileStubBuilders.EP_NAME, FileTypeExtensionPoint::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint(area, FileContextProvider.EP_NAME, FileContextProvider::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint(area, MetaDataContributor.EP_NAME, MetaDataContributor::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint(area, PsiAugmentProvider.EP_NAME, PsiAugmentProvider::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint(area, JavaMainMethodProvider.EP_NAME, JavaMainMethodProvider::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint(area, ContainerProvider.EP_NAME, ContainerProvider::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint(area, ClsCustomNavigationPolicy.EP_NAME, ClsCustomNavigationPolicy::class.java)
+    CoreApplicationEnvironment.registerExtensionPoint<ClassFileDecompilers.Decompiler>(area, ClassFileDecompilers.EP_NAME,
+                                                                                       ClassFileDecompilers.Decompiler::class.java)
+  }
+
+  private fun getClasspath(arguments: K2JVMCompilerArguments, libraries: List<Path>): List<File> {
+    val classpath = Lists.newArrayList<File>()
+    classpath.addAll(PathUtil.getJdkClassesRoots(File(CommonSettings.JAVA_HOME)))
+    libraries.mapTo(classpath) { it.toFile() }
+    if (arguments.classpath != null) {
+      val elements = arguments.classpath!!.split(delimiters = *charArrayOf(File.pathSeparatorChar), ignoreCase = false, limit = 0)
+      elements.mapTo(classpath) { File(it) }
+    }
+    return classpath
+  }
+}

--- a/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/translator/WebDemoTranslatorFacade.kt
+++ b/versions/1.4.0/src/main/java/org/jetbrains/webdemo/kotlin/impl/translator/WebDemoTranslatorFacade.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PRE_RELEASE_CLASS")
+package org.jetbrains.webdemo.kotlin.impl.translator
+
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.js.config.JSConfigurationKeys
+import org.jetbrains.kotlin.js.config.JsConfig
+import org.jetbrains.kotlin.js.facade.K2JSTranslator
+import org.jetbrains.kotlin.js.facade.MainCallParameters
+import org.jetbrains.kotlin.js.facade.TranslationResult
+import org.jetbrains.kotlin.js.facade.exceptions.TranslationException
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.webdemo.kotlin.datastructures.ErrorDescriptor
+import org.jetbrains.webdemo.kotlin.exceptions.KotlinCoreException
+import org.jetbrains.webdemo.kotlin.impl.WrapperSettings
+import org.jetbrains.webdemo.kotlin.impl.analyzer.ErrorAnalyzer
+import org.jetbrains.webdemo.kotlin.impl.environment.EnvironmentManager
+import java.util.*
+
+object WebDemoTranslatorFacade {
+
+    fun translateProjectWithCallToMain(files: List<KtFile>, arguments: Array<String>): org.jetbrains.webdemo.kotlin.datastructures.TranslationResult {
+        try {
+            return doTranslate(files, arguments)
+        } catch (e: Throwable) {
+            throw KotlinCoreException(e)
+        } finally {
+            EnvironmentManager.reinitializeJavaEnvironment()
+        }
+    }
+
+    @Throws(TranslationException::class)
+    private fun doTranslate(
+            files: List<KtFile>,
+            arguments: Array<String>
+    ): org.jetbrains.webdemo.kotlin.datastructures.TranslationResult {
+        val environment = EnvironmentManager.getEnvironment()
+        val currentProject = environment.project
+
+        val configuration = environment.configuration.copy()
+        configuration.put(CommonConfigurationKeys.MODULE_NAME, "moduleId")
+        configuration.put(JSConfigurationKeys.LIBRARIES, listOf(WrapperSettings.JS_LIB_ROOT.toString()))
+
+        val config = JsConfig(currentProject, configuration)
+        val reporter = object : JsConfig.Reporter() {
+            override fun error(message: String) {}
+
+            override fun warning(message: String) {}
+        }
+        val translator = K2JSTranslator(config)
+        val result = translator.translate(
+                reporter,
+                files,
+                MainCallParameters.mainWithArguments(Arrays.asList(*arguments)))
+        return if (result is TranslationResult.Success) {
+            org.jetbrains.webdemo.kotlin.datastructures.TranslationResult(
+                    "kotlin.kotlin.io.output.flush();\n" + result.getCode() + "\n" + "kotlin.kotlin.io.output.buffer;\n")
+
+        } else {
+            val errors = HashMap<String, List<ErrorDescriptor>>()
+            for (psiFile in files) {
+                errors.put(psiFile.name, ArrayList())
+            }
+            val errorAnalyzer = ErrorAnalyzer(files, currentProject)
+            errorAnalyzer.getErrorsFromDiagnostics(result.diagnostics.all(), errors)
+            org.jetbrains.webdemo.kotlin.datastructures.TranslationResult(errors)
+        }
+    }
+
+}


### PR DESCRIPTION
It fixes the use of Kotlin 1.3.50 for the current code snippets

I based on:

* https://github.com/JetBrains/kotlin-web-demo/tree/master/versions (latest supported version: 1.4-M2)
* https://mvnrepository.com/artifact/org.jetbrains.kotlin/ide-common-ij193/
* https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
* https://plugins.jetbrains.com/plugin/6954-kotlin/versions